### PR TITLE
Refactor run mutate

### DIFF
--- a/spec/functional/class_spec.rb
+++ b/spec/functional/class_spec.rb
@@ -36,7 +36,7 @@ describe 'Mutating a class' do
         end
       end
     """
-    run_simple '../../bin/mutate Thing spec/thing_spec.rb'
+    run_simple '../../exe/mutate Thing spec/thing_spec.rb'
   end
 
   it 'runs all possible mutations' do

--- a/spec/functional/class_spec.rb
+++ b/spec/functional/class_spec.rb
@@ -36,7 +36,7 @@ describe 'Mutating a class' do
         end
       end
     """
-    run_simple '../../exe/mutate Thing spec/thing_spec.rb'
+    mutate 'Thing spec/thing_spec.rb'
   end
 
   it 'runs all possible mutations' do

--- a/spec/functional/instance_method/array_spec.rb
+++ b/spec/functional/instance_method/array_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating arrays' do
               specify { Thing.new.to_a.should eq([1,2,3]) }
             end
           """
-          run_simple '../../bin/mutate Thing#to_a spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing#to_a spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating arrays' do
               specify { Thing.new.to_a.should respond_to(:length) }
             end
           """
-          run_simple '../../bin/mutate Thing#to_a spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing#to_a spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/instance_method/array_spec.rb
+++ b/spec/functional/instance_method/array_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating arrays' do
               specify { Thing.new.to_a.should eq([1,2,3]) }
             end
           """
-          run_simple '../../exe/mutate Thing#to_a spec/thing_spec.rb'
+          mutate 'Thing#to_a spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating arrays' do
               specify { Thing.new.to_a.should respond_to(:length) }
             end
           """
-          run_simple '../../exe/mutate Thing#to_a spec/thing_spec.rb'
+          mutate 'Thing#to_a spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/instance_method/boolean_spec.rb
+++ b/spec/functional/instance_method/boolean_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating booleans' do
               specify { Thing.new.should be_alive }
             end
           """
-          run_simple '../../exe/mutate Thing#alive? spec/thing_spec.rb'
+          mutate 'Thing#alive? spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating booleans' do
               specify { String(Thing.new.alive?).should =~ /true|false/ }
             end
           """
-          run_simple '../../exe/mutate Thing#alive? spec/thing_spec.rb'
+          mutate 'Thing#alive? spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do
@@ -68,7 +68,7 @@ describe 'Mutating booleans' do
               specify { Thing.new.should_not be_alive }
             end
           """
-          run_simple '../../exe/mutate Thing#alive? spec/thing_spec.rb'
+          mutate 'Thing#alive? spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -85,7 +85,7 @@ describe 'Mutating booleans' do
               specify { String(Thing.new.alive?).should =~ /true|false/ }
             end
           """
-          run_simple '../../exe/mutate Thing#alive? spec/thing_spec.rb'
+          mutate 'Thing#alive? spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/instance_method/boolean_spec.rb
+++ b/spec/functional/instance_method/boolean_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating booleans' do
               specify { Thing.new.should be_alive }
             end
           """
-          run_simple '../../bin/mutate Thing#alive? spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing#alive? spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating booleans' do
               specify { String(Thing.new.alive?).should =~ /true|false/ }
             end
           """
-          run_simple '../../bin/mutate Thing#alive? spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing#alive? spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do
@@ -68,7 +68,7 @@ describe 'Mutating booleans' do
               specify { Thing.new.should_not be_alive }
             end
           """
-          run_simple '../../bin/mutate Thing#alive? spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing#alive? spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -85,7 +85,7 @@ describe 'Mutating booleans' do
               specify { String(Thing.new.alive?).should =~ /true|false/ }
             end
           """
-          run_simple '../../bin/mutate Thing#alive? spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing#alive? spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/instance_method/fixnum_spec.rb
+++ b/spec/functional/instance_method/fixnum_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating fixnums' do
               specify { Life.new.answer.should eq(42) }
             end
           """
-          run_simple '../../exe/mutate Life#answer spec/life_spec.rb'
+          mutate 'Life#answer spec/life_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating fixnums' do
               specify { Life.new.answer.should be_a(Fixnum) }
             end
           """
-          run_simple '../../exe/mutate Life#answer spec/life_spec.rb'
+          mutate 'Life#answer spec/life_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/instance_method/fixnum_spec.rb
+++ b/spec/functional/instance_method/fixnum_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating fixnums' do
               specify { Life.new.answer.should eq(42) }
             end
           """
-          run_simple '../../bin/mutate Life#answer spec/life_spec.rb'
+          run_simple '../../exe/mutate Life#answer spec/life_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating fixnums' do
               specify { Life.new.answer.should be_a(Fixnum) }
             end
           """
-          run_simple '../../bin/mutate Life#answer spec/life_spec.rb'
+          run_simple '../../exe/mutate Life#answer spec/life_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/instance_method/float_spec.rb
+++ b/spec/functional/instance_method/float_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating floats' do
               specify { Life.new.answer.should eq(42.5) }
             end
           """
-          run_simple '../../bin/mutate Life#answer spec/life_spec.rb'
+          run_simple '../../exe/mutate Life#answer spec/life_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating floats' do
               specify { Life.new.answer.should be_a(Float) }
             end
           """
-          run_simple '../../bin/mutate Life#answer spec/life_spec.rb'
+          run_simple '../../exe/mutate Life#answer spec/life_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/instance_method/float_spec.rb
+++ b/spec/functional/instance_method/float_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating floats' do
               specify { Life.new.answer.should eq(42.5) }
             end
           """
-          run_simple '../../exe/mutate Life#answer spec/life_spec.rb'
+          mutate 'Life#answer spec/life_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating floats' do
               specify { Life.new.answer.should be_a(Float) }
             end
           """
-          run_simple '../../exe/mutate Life#answer spec/life_spec.rb'
+          mutate 'Life#answer spec/life_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/instance_method/hash_spec.rb
+++ b/spec/functional/instance_method/hash_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating hashes' do
               specify { Thing.new.to_hash[:foo][:bar].should eq(3) }
             end
           """
-          run_simple '../../bin/mutate Thing#to_hash spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing#to_hash spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating hashes' do
               specify { Thing.new.to_hash[:foo][:bar].should be_kind_of(Fixnum) }
             end
           """
-          run_simple '../../bin/mutate Thing#to_hash spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing#to_hash spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/instance_method/hash_spec.rb
+++ b/spec/functional/instance_method/hash_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating hashes' do
               specify { Thing.new.to_hash[:foo][:bar].should eq(3) }
             end
           """
-          run_simple '../../exe/mutate Thing#to_hash spec/thing_spec.rb'
+          mutate 'Thing#to_hash spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating hashes' do
               specify { Thing.new.to_hash[:foo][:bar].should be_kind_of(Fixnum) }
             end
           """
-          run_simple '../../exe/mutate Thing#to_hash spec/thing_spec.rb'
+          mutate 'Thing#to_hash spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/instance_method/range_spec.rb
+++ b/spec/functional/instance_method/range_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating ranges' do
               specify { Thing.new.a_range.should eq('a'..'z') }
             end
           """
-          run_simple '../../exe/mutate Thing#a_range spec/thing_spec.rb'
+          mutate 'Thing#a_range spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating ranges' do
               specify { Thing.new.a_range.should be_a(Range) }
             end
           """
-          run_simple '../../exe/mutate Thing#a_range spec/thing_spec.rb'
+          mutate 'Thing#a_range spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/instance_method/range_spec.rb
+++ b/spec/functional/instance_method/range_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating ranges' do
               specify { Thing.new.a_range.should eq('a'..'z') }
             end
           """
-          run_simple '../../bin/mutate Thing#a_range spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing#a_range spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating ranges' do
               specify { Thing.new.a_range.should be_a(Range) }
             end
           """
-          run_simple '../../bin/mutate Thing#a_range spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing#a_range spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/instance_method/regex_spec.rb
+++ b/spec/functional/instance_method/regex_spec.rb
@@ -24,7 +24,7 @@ describe 'Mutating regexen' do
               end
             end
           """
-          run_simple '../../exe/mutate Thing#regex spec/thing_spec.rb'
+          mutate 'Thing#regex spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -41,7 +41,7 @@ describe 'Mutating regexen' do
               specify { Thing.new.regex.should be_kind_of(Regexp) }
             end
           """
-          run_simple '../../exe/mutate Thing#regex spec/thing_spec.rb'
+          mutate 'Thing#regex spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/instance_method/regex_spec.rb
+++ b/spec/functional/instance_method/regex_spec.rb
@@ -24,7 +24,7 @@ describe 'Mutating regexen' do
               end
             end
           """
-          run_simple '../../bin/mutate Thing#regex spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing#regex spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -41,7 +41,7 @@ describe 'Mutating regexen' do
               specify { Thing.new.regex.should be_kind_of(Regexp) }
             end
           """
-          run_simple '../../bin/mutate Thing#regex spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing#regex spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/instance_method/string_spec.rb
+++ b/spec/functional/instance_method/string_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating strings' do
               specify { Thing.new.a_string.should eq('foo') }
             end
           """
-          run_simple '../../bin/mutate Thing#a_string spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing#a_string spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating strings' do
               specify { Thing.new.a_string.should be_a(String) }
             end
           """
-          run_simple '../../bin/mutate Thing#a_string spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing#a_string spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/instance_method/string_spec.rb
+++ b/spec/functional/instance_method/string_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating strings' do
               specify { Thing.new.a_string.should eq('foo') }
             end
           """
-          run_simple '../../exe/mutate Thing#a_string spec/thing_spec.rb'
+          mutate 'Thing#a_string spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating strings' do
               specify { Thing.new.a_string.should be_a(String) }
             end
           """
-          run_simple '../../exe/mutate Thing#a_string spec/thing_spec.rb'
+          mutate 'Thing#a_string spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/instance_method/symbol_spec.rb
+++ b/spec/functional/instance_method/symbol_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating symbols' do
               specify { Thing.new.a_symbol.should eq(:foo) }
             end
           """
-          run_simple '../../exe/mutate Thing#a_symbol spec/thing_spec.rb'
+          mutate 'Thing#a_symbol spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating symbols' do
               specify { Thing.new.a_symbol.should be_a(Symbol) }
             end
           """
-          run_simple '../../exe/mutate Thing#a_symbol spec/thing_spec.rb'
+          mutate 'Thing#a_symbol spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/instance_method/symbol_spec.rb
+++ b/spec/functional/instance_method/symbol_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating symbols' do
               specify { Thing.new.a_symbol.should eq(:foo) }
             end
           """
-          run_simple '../../bin/mutate Thing#a_symbol spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing#a_symbol spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating symbols' do
               specify { Thing.new.a_symbol.should be_a(Symbol) }
             end
           """
-          run_simple '../../bin/mutate Thing#a_symbol spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing#a_symbol spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/reporter/method_loaded_spec.rb
+++ b/spec/functional/reporter/method_loaded_spec.rb
@@ -18,7 +18,7 @@ describe 'Reporter' do
             specify { Thing.new.should be_alive }
           end
         """
-        run_simple '../../exe/mutate Thing#alive? spec/thing_spec.rb'
+        mutate 'Thing#alive? spec/thing_spec.rb'
       end
 
       it 'displays the number of possible mutations' do
@@ -45,7 +45,7 @@ STR
             specify { Thing.new.alive?.should be_nil }
           end
         """
-        run_simple '../../exe/mutate Thing#alive? spec/thing_spec.rb'
+        mutate 'Thing#alive? spec/thing_spec.rb'
       end
 
       it 'displays a warning that there are no possible mutations' do

--- a/spec/functional/reporter/method_loaded_spec.rb
+++ b/spec/functional/reporter/method_loaded_spec.rb
@@ -18,7 +18,7 @@ describe 'Reporter' do
             specify { Thing.new.should be_alive }
           end
         """
-        run_simple '../../bin/mutate Thing#alive? spec/thing_spec.rb'
+        run_simple '../../exe/mutate Thing#alive? spec/thing_spec.rb'
       end
 
       it 'displays the number of possible mutations' do
@@ -45,7 +45,7 @@ STR
             specify { Thing.new.alive?.should be_nil }
           end
         """
-        run_simple '../../bin/mutate Thing#alive? spec/thing_spec.rb'
+        run_simple '../../exe/mutate Thing#alive? spec/thing_spec.rb'
       end
 
       it 'displays a warning that there are no possible mutations' do

--- a/spec/functional/reporter/running_mutations_spec.rb
+++ b/spec/functional/reporter/running_mutations_spec.rb
@@ -27,7 +27,7 @@ CODE
       ENV['RANDOM_RANGE_MIN'] = '1'
       ENV['RANDOM_RANGE_MAX'] = '3'
 
-      run_simple '../../bin/mutate Thing#alive? spec/thing_spec.rb'
+      run_simple '../../exe/mutate Thing#alive? spec/thing_spec.rb'
     end
 
     after do

--- a/spec/functional/reporter/running_mutations_spec.rb
+++ b/spec/functional/reporter/running_mutations_spec.rb
@@ -27,7 +27,7 @@ CODE
       ENV['RANDOM_RANGE_MIN'] = '1'
       ENV['RANDOM_RANGE_MAX'] = '3'
 
-      run_simple '../../exe/mutate Thing#alive? spec/thing_spec.rb'
+      mutate 'Thing#alive? spec/thing_spec.rb'
     end
 
     after do

--- a/spec/functional/runners/rspec_spec.rb
+++ b/spec/functional/runners/rspec_spec.rb
@@ -13,7 +13,7 @@ describe 'Runners' do
             specify { Thing.new.should_not be_alive }
           end
         """
-        run_simple '../../exe/mutate Thing#alive? spec/thing_spec.rb', false
+        mutate 'Thing#alive? spec/thing_spec.rb', false
       end
 
       it 'causes the run to abort' do

--- a/spec/functional/runners/rspec_spec.rb
+++ b/spec/functional/runners/rspec_spec.rb
@@ -13,7 +13,7 @@ describe 'Runners' do
             specify { Thing.new.should_not be_alive }
           end
         """
-        run_simple '../../bin/mutate Thing#alive? spec/thing_spec.rb', false
+        run_simple '../../exe/mutate Thing#alive? spec/thing_spec.rb', false
       end
 
       it 'causes the run to abort' do

--- a/spec/functional/singleton_method/array_spec.rb
+++ b/spec/functional/singleton_method/array_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating arrays' do
               specify { Thing.to_a.should eq([1,2,3]) }
             end
           """
-          run_simple '../../exe/mutate Thing.to_a spec/thing_spec.rb'
+          mutate 'Thing.to_a spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating arrays' do
               specify { Thing.to_a.should respond_to(:length) }
             end
           """
-          run_simple '../../exe/mutate Thing.to_a spec/thing_spec.rb'
+          mutate 'Thing.to_a spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/singleton_method/array_spec.rb
+++ b/spec/functional/singleton_method/array_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating arrays' do
               specify { Thing.to_a.should eq([1,2,3]) }
             end
           """
-          run_simple '../../bin/mutate Thing.to_a spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing.to_a spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating arrays' do
               specify { Thing.to_a.should respond_to(:length) }
             end
           """
-          run_simple '../../bin/mutate Thing.to_a spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing.to_a spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/singleton_method/boolean_spec.rb
+++ b/spec/functional/singleton_method/boolean_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating booleans' do
               specify { Thing.should be_alive }
             end
           """
-          run_simple '../../exe/mutate Thing.alive? spec/thing_spec.rb'
+          mutate 'Thing.alive? spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating booleans' do
               specify { String(Thing.alive?).should =~ /true|false/ }
             end
           """
-          run_simple '../../exe/mutate Thing.alive? spec/thing_spec.rb'
+          mutate 'Thing.alive? spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do
@@ -68,7 +68,7 @@ describe 'Mutating booleans' do
               specify { Thing.should_not be_alive }
             end
           """
-          run_simple '../../exe/mutate Thing.alive? spec/thing_spec.rb'
+          mutate 'Thing.alive? spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -85,7 +85,7 @@ describe 'Mutating booleans' do
               specify { String(Thing.alive?).should =~ /true|false/ }
             end
           """
-          run_simple '../../exe/mutate Thing.alive? spec/thing_spec.rb'
+          mutate 'Thing.alive? spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/singleton_method/boolean_spec.rb
+++ b/spec/functional/singleton_method/boolean_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating booleans' do
               specify { Thing.should be_alive }
             end
           """
-          run_simple '../../bin/mutate Thing.alive? spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing.alive? spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating booleans' do
               specify { String(Thing.alive?).should =~ /true|false/ }
             end
           """
-          run_simple '../../bin/mutate Thing.alive? spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing.alive? spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do
@@ -68,7 +68,7 @@ describe 'Mutating booleans' do
               specify { Thing.should_not be_alive }
             end
           """
-          run_simple '../../bin/mutate Thing.alive? spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing.alive? spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -85,7 +85,7 @@ describe 'Mutating booleans' do
               specify { String(Thing.alive?).should =~ /true|false/ }
             end
           """
-          run_simple '../../bin/mutate Thing.alive? spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing.alive? spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/singleton_method/fixnum_spec.rb
+++ b/spec/functional/singleton_method/fixnum_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating fixnums' do
               specify { Life.answer.should eq(42) }
             end
           """
-          run_simple '../../bin/mutate Life.answer spec/life_spec.rb'
+          run_simple '../../exe/mutate Life.answer spec/life_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating fixnums' do
               specify { Life.answer.should be_a(Fixnum) }
             end
           """
-          run_simple '../../bin/mutate Life.answer spec/life_spec.rb'
+          run_simple '../../exe/mutate Life.answer spec/life_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/singleton_method/fixnum_spec.rb
+++ b/spec/functional/singleton_method/fixnum_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating fixnums' do
               specify { Life.answer.should eq(42) }
             end
           """
-          run_simple '../../exe/mutate Life.answer spec/life_spec.rb'
+          mutate 'Life.answer spec/life_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating fixnums' do
               specify { Life.answer.should be_a(Fixnum) }
             end
           """
-          run_simple '../../exe/mutate Life.answer spec/life_spec.rb'
+          mutate 'Life.answer spec/life_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/singleton_method/float_spec.rb
+++ b/spec/functional/singleton_method/float_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating floats' do
               specify { Life.answer.should eq(42.05) }
             end
           """
-          run_simple '../../bin/mutate Life.answer spec/life_spec.rb'
+          run_simple '../../exe/mutate Life.answer spec/life_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating floats' do
               specify { Life.answer.should be_a(Float) }
             end
           """
-          run_simple '../../bin/mutate Life.answer spec/life_spec.rb'
+          run_simple '../../exe/mutate Life.answer spec/life_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/singleton_method/float_spec.rb
+++ b/spec/functional/singleton_method/float_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating floats' do
               specify { Life.answer.should eq(42.05) }
             end
           """
-          run_simple '../../exe/mutate Life.answer spec/life_spec.rb'
+          mutate 'Life.answer spec/life_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating floats' do
               specify { Life.answer.should be_a(Float) }
             end
           """
-          run_simple '../../exe/mutate Life.answer spec/life_spec.rb'
+          mutate 'Life.answer spec/life_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/singleton_method/hash_spec.rb
+++ b/spec/functional/singleton_method/hash_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating hashes' do
               specify { Thing.to_hash[:foo][:bar].should eq(3) }
             end
           """
-          run_simple '../../bin/mutate Thing.to_hash spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing.to_hash spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating hashes' do
               specify { Thing.to_hash[:foo][:bar].should be_kind_of(Fixnum) }
             end
           """
-          run_simple '../../bin/mutate Thing.to_hash spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing.to_hash spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/singleton_method/hash_spec.rb
+++ b/spec/functional/singleton_method/hash_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating hashes' do
               specify { Thing.to_hash[:foo][:bar].should eq(3) }
             end
           """
-          run_simple '../../exe/mutate Thing.to_hash spec/thing_spec.rb'
+          mutate 'Thing.to_hash spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating hashes' do
               specify { Thing.to_hash[:foo][:bar].should be_kind_of(Fixnum) }
             end
           """
-          run_simple '../../exe/mutate Thing.to_hash spec/thing_spec.rb'
+          mutate 'Thing.to_hash spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/singleton_method/range_spec.rb
+++ b/spec/functional/singleton_method/range_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating ranges' do
               specify { Thing.a_range.should eq('a'..'z') }
             end
           """
-          run_simple '../../exe/mutate Thing.a_range spec/thing_spec.rb'
+          mutate 'Thing.a_range spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating ranges' do
               specify { Thing.a_range.should be_a(Range) }
             end
           """
-          run_simple '../../exe/mutate Thing.a_range spec/thing_spec.rb'
+          mutate 'Thing.a_range spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/singleton_method/range_spec.rb
+++ b/spec/functional/singleton_method/range_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating ranges' do
               specify { Thing.a_range.should eq('a'..'z') }
             end
           """
-          run_simple '../../bin/mutate Thing.a_range spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing.a_range spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating ranges' do
               specify { Thing.a_range.should be_a(Range) }
             end
           """
-          run_simple '../../bin/mutate Thing.a_range spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing.a_range spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/singleton_method/regex_spec.rb
+++ b/spec/functional/singleton_method/regex_spec.rb
@@ -24,7 +24,7 @@ describe 'Mutating regexen' do
               end
             end
           """
-          run_simple '../../exe/mutate Thing.regex spec/thing_spec.rb'
+          mutate 'Thing.regex spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -41,7 +41,7 @@ describe 'Mutating regexen' do
               specify { Thing.regex.should be_kind_of(Regexp) }
             end
           """
-          run_simple '../../exe/mutate Thing.regex spec/thing_spec.rb'
+          mutate 'Thing.regex spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/singleton_method/regex_spec.rb
+++ b/spec/functional/singleton_method/regex_spec.rb
@@ -24,7 +24,7 @@ describe 'Mutating regexen' do
               end
             end
           """
-          run_simple '../../bin/mutate Thing.regex spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing.regex spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -41,7 +41,7 @@ describe 'Mutating regexen' do
               specify { Thing.regex.should be_kind_of(Regexp) }
             end
           """
-          run_simple '../../bin/mutate Thing.regex spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing.regex spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/singleton_method/string_spec.rb
+++ b/spec/functional/singleton_method/string_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating string' do
               specify { Thing.a_string.should eq('foo') }
             end
           """
-          run_simple '../../bin/mutate Thing.a_string spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing.a_string spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating string' do
               specify { Thing.a_string.should be_a(String) }
             end
           """
-          run_simple '../../bin/mutate Thing.a_string spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing.a_string spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/singleton_method/string_spec.rb
+++ b/spec/functional/singleton_method/string_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating string' do
               specify { Thing.a_string.should eq('foo') }
             end
           """
-          run_simple '../../exe/mutate Thing.a_string spec/thing_spec.rb'
+          mutate 'Thing.a_string spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating string' do
               specify { Thing.a_string.should be_a(String) }
             end
           """
-          run_simple '../../exe/mutate Thing.a_string spec/thing_spec.rb'
+          mutate 'Thing.a_string spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/singleton_method/symbol_spec.rb
+++ b/spec/functional/singleton_method/symbol_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating symbols' do
               specify { Thing.a_symbol.should eq(:foo) }
             end
           """
-          run_simple '../../exe/mutate Thing.a_symbol spec/thing_spec.rb'
+          mutate 'Thing.a_symbol spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating symbols' do
               specify { Thing.a_symbol.should be_a(Symbol) }
             end
           """
-          run_simple '../../exe/mutate Thing.a_symbol spec/thing_spec.rb'
+          mutate 'Thing.a_symbol spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/functional/singleton_method/symbol_spec.rb
+++ b/spec/functional/singleton_method/symbol_spec.rb
@@ -22,7 +22,7 @@ describe 'Mutating symbols' do
               specify { Thing.a_symbol.should eq(:foo) }
             end
           """
-          run_simple '../../bin/mutate Thing.a_symbol spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing.a_symbol spec/thing_spec.rb'
         end
 
         specify 'the mutation passes' do
@@ -39,7 +39,7 @@ describe 'Mutating symbols' do
               specify { Thing.a_symbol.should be_a(Symbol) }
             end
           """
-          run_simple '../../bin/mutate Thing.a_symbol spec/thing_spec.rb'
+          run_simple '../../exe/mutate Thing.a_symbol spec/thing_spec.rb'
         end
 
         specify 'the mutation fails' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ RSpec.configure do |config|
   config.filter_run :focus
   config.run_all_when_everything_filtered = true
   config.extend ExampleGroupHelpers
+  config.include ExampleHelpers
 
   {:example_group => {:file_path => /spec\/functional/}}.tap do |options|
     config.include Aruba::Api, options

--- a/spec/support/example_helpers.rb
+++ b/spec/support/example_helpers.rb
@@ -1,0 +1,5 @@
+module ExampleHelpers
+  def mutate(cmd, fail_on_error = true)
+    run_simple "../../exe/mutate #{cmd}", fail_on_error
+  end
+end


### PR DESCRIPTION
This change fixes the path to point to the new location of the mutate binary and wraps up the `run_simple` call in a `mutant` spec helper method.
