### PR TITLE
Empty hash assignments no longer make the mutation fail

### DIFF
--- a/lib/mutant/literal.rb
+++ b/lib/mutant/literal.rb
@@ -13,7 +13,15 @@ module Mutant
       @class.new(@node).swap
     end
 
+    def changes_on_swap?
+      @class.changes_on_swap?(@node)
+    end
+
     class BaseLiteral
+      def self.changes_on_swap?(node)
+        true
+      end
+
       def initialize(node)
         @node = node
       end
@@ -83,6 +91,10 @@ module Mutant
     end
 
     class HashLiteral < BaseLiteral
+      def self.changes_on_swap?(node)
+        node.array != []
+      end
+
       def swap
         new_body = @node.array.each_slice(2).inject([]) do |body, (key, value)|
           new_value = literal_class(value).new(value.clone).swap

--- a/lib/mutant/mutatee.rb
+++ b/lib/mutant/mutatee.rb
@@ -21,7 +21,8 @@ module Mutant
 
     def set_mutations
       nodes.each do |node|
-        @mutations << Mutation.new(node, body.array)
+        mutation = Mutation.new(node, body.array)
+        @mutations << mutation if mutation.mutatable?
       end
     end
 

--- a/lib/mutant/mutation.rb
+++ b/lib/mutant/mutation.rb
@@ -10,7 +10,7 @@ module Mutant
       @mutated = false
     end
 
-    def_delegators :@node, :line, :from, :to
+    def_delegators :@node, :line, :from, :to, :mutatable?
 
     def mutated?
       @mutated

--- a/lib/mutant/node.rb
+++ b/lib/mutant/node.rb
@@ -22,5 +22,9 @@ module Mutant
     def swap
       @copy = Literal.new(copy).swap
     end
+
+    def mutatable?
+      Literal.new(@copy).changes_on_swap?
+    end
   end
 end

--- a/spec/functional/instance_method/hash_spec.rb
+++ b/spec/functional/instance_method/hash_spec.rb
@@ -2,6 +2,36 @@ require 'spec_helper'
 
 describe 'Mutating hashes' do
   context 'for an instance method' do
+    context 'that contains {}' do
+      before do
+        write_file 'thing.rb', """
+          class Thing
+            def to_hash
+              {}
+            end
+          end
+        """
+      end
+
+      context 'with an expectation that the method returns {}' do
+        before do
+          write_file 'spec/thing_spec.rb', """
+            $: << '.'
+            require 'thing'
+
+            describe 'Thing#to_hash' do
+              specify { Thing.new.to_hash.should === {} }
+            end
+          """
+          mutate 'Thing#to_hash spec/thing_spec.rb'
+        end
+
+        specify 'there are no possible mutations' do
+          all_output.should include('no possible mutations')
+        end
+      end
+    end
+
     context 'that contains {:foo => {:bar => 3}}' do
       before do
         write_file 'thing.rb', """


### PR DESCRIPTION
For #5

This allows mutations to be checked to ensure that they can actually be mutated. If they can't, they are rejected from the mutation list.

So far, this only applies to hashes, but can easily be applied to other classes by overriding changes_on_swap? for that class.
